### PR TITLE
Try identifying json strings before json.Unmarshal for better performance

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ import (
 )
 
 var ErrMismatchConf = errors.New("Your conf is wrong:")
+var errNotJSON = errors.New("not a valid json")
 
 type ErrKeyNotFound struct {
 	Key string
@@ -212,6 +213,9 @@ func Get(key string) (interface{}, error) {
 func expandEnv(s string) (interface{}, error) {
 	raw := os.ExpandEnv(s)
 	var jsonMap map[string]interface{}
+	if len(raw) == 0 || (raw[0] != '{' && raw[0] != '[') {
+		return raw, errNotJSON
+	}
 	err := json.Unmarshal([]byte(raw), &jsonMap)
 	if err != nil {
 		var jsonSlice []interface{}


### PR DESCRIPTION
This yields a much better performance than always trying to parse
strings as JSON. This code path showed up while profiling tsuru.